### PR TITLE
Generate Software Bill of Materials (SBOM) manifest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,3 +165,16 @@ stages:
     #    packagesToPush: $(Build.ArtifactStagingDirectory)/package/*.nupkg
     #    nuGetFeedType: external
     #    publishFeedCredentials: 'xamarin-impl public feed'
+
+- stage: SBOM
+  displayName: 'Software Bill of Materials'
+  dependsOn:
+  - Upload
+
+  jobs:
+  - template: compliance/sbom/job.v1.yml@templates          # Software Bill of Materials (SBOM): https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator
+    parameters:
+      packageName: 'Mobile Essentials'
+      artifactNames: ['package']
+      packageFilter: '*.vsix;*.nupkg'
+      packageVersionRegex: '(?i)^Merq\.(?<version>\d+\.\d+\.\d+).vsix$'


### PR DESCRIPTION
Related work item: VS #[1484113](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1484113)

Per Executive Order (EO) produce a Software Bill of Materials (SBOM) capturing the produced vsix and nuget files from a dedicated job
https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator

As a result of this change you will find an artifact named `sbom` attached to each build.  Within that artifact is a `manifest.json` file under a `_manifest` directory capturing all of the files that constitute the `Software Bill of Materials` 

The `sbom` job currently captures the .vsix and .nuget files published (uploaded) by the build. The .vsix is inserted into Visual Studio for Windows based on the following insertion manifest
https://devdiv.visualstudio.com/DevDiv/_git/VS?version=GBrel/d17.2&path=/.corext/Configs/vsmobdevtools-components.json