### PR TITLE
Target windows EO compliant agent pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,9 @@ stages:
   jobs:
   - job: Build
     pool:
-      vmImage: windows-2019
+      name: AzurePipelines-EO
+      demands:
+      - ImageOverride -equals AzurePipelinesWindows2022compliant
     steps:
     - checkout: self
       clean: true
@@ -130,7 +132,10 @@ stages:
   jobs:
   - job: Upload
     pool:
-      vmImage: windows-2022
+      name: AzurePipelines-EO
+      demands:
+      - ImageOverride -equals AzurePipelinesWindows2022compliant
+
     steps:
     - checkout: self
 


### PR DESCRIPTION
Per Executive Order (EO) migrate all jobs that currently use a Windows hosted pool to instead use the `AzurePipelines-EO` agent pool instead.

Executive Order
https://eng.ms/docs/initiatives/executive-order/executive-order-requirements/executiveorderoncybersecurity/buildinfraops

