### PR TITLE
[cg] Remove legacy netfx-System.StringResources package

### DIFF
--- a/src/Core/Merq.Core/EventStream.cs
+++ b/src/Core/Merq.Core/EventStream.cs
@@ -51,7 +51,7 @@ namespace Merq
 		{
 			if (@event == null) throw new ArgumentNullException(nameof(@event));
 			if (!IsValid<TEvent>())
-				throw new NotSupportedException(Strings.EventStream.PublishedEventNotPublic);
+				throw new NotSupportedException(Resources.EventStream_PublishedEventNotPublic);
 
 			var eventType = @event.GetType().GetTypeInfo();
 
@@ -64,7 +64,7 @@ namespace Merq
 		public virtual IObservable<TEvent> Of<TEvent>()
 		{
 			if (!IsValid<TEvent>())
-				throw new NotSupportedException(Strings.EventStream.SubscribedEventNotPublic);
+				throw new NotSupportedException(Resources.EventStream_SubscribedEventNotPublic);
 
 			var subject = (IObservable<TEvent>)subjects.GetOrAdd(typeof(TEvent).GetTypeInfo(), info =>
 			{

--- a/src/Core/Merq.Core/Merq.Core.csproj
+++ b/src/Core/Merq.Core/Merq.Core.csproj
@@ -19,7 +19,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
-    <PackageReference Include="netfx-System.StringResources" Version="3.0.14" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CSharp" Version="4.0.1" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Vsix/Merq.Vsix/Components/CommandBusComponent.cs
+++ b/src/Vsix/Merq.Vsix/Components/CommandBusComponent.cs
@@ -110,7 +110,7 @@ namespace Merq
 			{
 				var handler = components.GetExtensions<ICommandHandler<TCommand>>().FirstOrDefault();
 				if (handler == null)
-					throw new NotSupportedException(Strings.CommandBus.NoHandler(command.GetType()));
+					throw new NotSupportedException(string.Format(Resources.CommandBus_NoHandler, command.GetType()));
 
 				handler.Execute(command);
 			}
@@ -119,7 +119,7 @@ namespace Merq
 			{
 				var handler = components.GetExtensions<IAsyncCommandHandler<TCommand>>().FirstOrDefault();
 				if (handler == null)
-					throw new NotSupportedException(Strings.CommandBus.NoHandler(command.GetType()));
+					throw new NotSupportedException(string.Format(Resources.CommandBus_NoHandler, command.GetType()));
 
 				return handler.ExecuteAsync(command, cancellation);
 			}
@@ -138,7 +138,7 @@ namespace Merq
 			{
 				var handler = components.GetExtensions<ICommandHandler<TCommand, TResult>>().FirstOrDefault();
 				if (handler == null)
-					throw new NotSupportedException(Strings.CommandBus.NoHandler(command.GetType()));
+					throw new NotSupportedException(string.Format(Resources.CommandBus_NoHandler, command.GetType()));
 
 				return handler.Execute(command);
 			}
@@ -147,7 +147,7 @@ namespace Merq
 			{
 				var handler = components.GetExtensions<IAsyncCommandHandler<TCommand, TResult>>().FirstOrDefault();
 				if (handler == null)
-					throw new NotSupportedException(Strings.CommandBus.NoHandler(command.GetType()));
+					throw new NotSupportedException(string.Format(Resources.CommandBus_NoHandler, command.GetType()));
 
 				return handler.ExecuteAsync(command, cancellation);
 			}

--- a/src/Vsix/Merq.Vsix/Merq.Vsix.csproj
+++ b/src/Vsix/Merq.Vsix/Merq.Vsix.csproj
@@ -70,7 +70,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
-    <PackageReference Include="netfx-System.StringResources" Version="3.0.14" PrivateAssets="all" />
     <PackageReference Include="Clarius.VisualStudio" Version="2.0.12" />
     <PackageReference Include="Xamarin.VSSDK" Version="0.4.0-alpha.24" />
     <PackageReference Include="Xamarin.VSSDK.BuildTools" Version="0.4.0-alpha.24" />


### PR DESCRIPTION
We need to provide license information of all the 3rd party packages we depend on, and this legacy one is missing its license. Since it doesn't seem to be maintained, it's better to remove it. On top of that, it was adding much value.

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1552394
AB#1552394