### PR TITLE
[security] Add Arithmetic Bounds Checking for Debug builds

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,6 +17,7 @@
 		<PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(MSBuildThisFileDirectory)../pack</PackageOutputPath>
 		<GeneratePackageOnBuild>$(CI)</GeneratePackageOnBuild>
 		<PackageOnBuild>$(CI)</PackageOnBuild>
+		<CheckForOverflowUnderflow Condition=" '$(Configuration)' == 'Debug' ">true</CheckForOverflowUnderflow>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
To satisfy security compliance (https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#Zguide), we add this check for debug builds so we can catch additional potential errors regarding overflows
See more: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/language#checkforoverflowunderflow

AB#1546961