### PR TITLE
[security] Updated PackageReference versions to satisfy compliance re…

### DIFF
--- a/src/Core/Merq.Core.Tests/Merq.Core.Tests.csproj
+++ b/src/Core/Merq.Core.Tests/Merq.Core.Tests.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
-    <PackageReference Include="Moq" Version="4.5.10" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.msbuild" Version="2.3.1" />
+    <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.4" PrivateAssets="all" />
+    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="xunit.runner.msbuild" Version="2.4.1" />
     <PackageReference Include="System.Reactive" Version="3.0.0" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="3.0.0" />
   </ItemGroup>

--- a/src/Core/Merq.Core/Merq.Core.csproj
+++ b/src/Core/Merq.Core/Merq.Core.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
+    <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CSharp" Version="4.0.1" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Core/Merq/Merq.csproj
+++ b/src/Core/Merq/Merq.csproj
@@ -17,12 +17,12 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Merq.props', '$(MSBuildThisFileDirectory)'))" />
 
   <ItemGroup>
-    <PackageReference Include="IFluentInterface" Version="2.0.3" PrivateAssets="all" />
+    <PackageReference Include="IFluentInterface" Version="2.1.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
+    <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.4" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,7 +23,7 @@
 	<ItemGroup>
 		<PackageReference Include="MSBuilder" Version="0.2.0" PrivateAssets="All" />
 		<PackageReference Include="NuGet.Build.Packaging" Version="0.2.2" PrivateAssets="All" />
-		<PackageReference Include="GitInfo" Version="2.0.11" PrivateAssets="All" />
+		<PackageReference Include="GitInfo" Version="2.2.0" PrivateAssets="All" />
 	</ItemGroup>
 
 	<!-- These are replaced after restore by GitInfo.targets -->

--- a/src/Merq.VisualStudio.proj
+++ b/src/Merq.VisualStudio.proj
@@ -50,8 +50,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="MSBuilder" Version="0.2.0" />
-		<PackageReference Include="MSBuilder.VsixDependency" Version="0.2.7" />
-		<PackageReference Include="GitInfo" Version="1.1.48" PrivateAssets="All" />
+		<PackageReference Include="MSBuilder.VsixDependency" Version="0.2.16" />
+		<PackageReference Include="GitInfo" Version="2.20" PrivateAssets="All" />
 		<PackageReference Include="NuGet.Build.Packaging" Version="*" PrivateAssets="All" />
 	</ItemGroup>
 

--- a/src/Version.targets
+++ b/src/Version.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="2.0.11" PrivateAssets="all" />
+    <PackageReference Include="GitInfo" Version="2.2.0" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Vsix/Merq.Vsix.IntegrationTests/Merq.Vsix.IntegrationTests.csproj
+++ b/src/Vsix/Merq.Vsix.IntegrationTests/Merq.Vsix.IntegrationTests.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.msbuild" Version="2.3.1" />
+    <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.4" PrivateAssets="all" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="xunit.runner.msbuild" Version="2.4.1" />
     <PackageReference Include="xunit.vsix" Version="0.2.72" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.7.18" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.0" Version="12.0.30110" />

--- a/src/Vsix/Merq.Vsix.Tests/Merq.Vsix.Tests.csproj
+++ b/src/Vsix/Merq.Vsix.Tests/Merq.Vsix.Tests.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
+    <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.4" PrivateAssets="all" />
     <PackageReference Include="System.Reactive" Version="3.0.0" />
-    <PackageReference Include="Moq" Version="4.5.10" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.msbuild" Version="2.3.1" />
+    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="xunit.runner.msbuild" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Vsix/Merq.Vsix/Merq.Vsix.csproj
+++ b/src/Vsix/Merq.Vsix/Merq.Vsix.csproj
@@ -75,8 +75,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
-    <PackageReference Include="Clarius.VisualStudio" Version="2.0.12" />
+    <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.4" PrivateAssets="all" />
+    <PackageReference Include="Clarius.VisualStudio" Version="2.0.14" />
     <PackageReference Include="Xamarin.VSSDK" Version="0.4.0-alpha.24" />
     <PackageReference Include="Xamarin.VSSDK.BuildTools" Version="0.4.0-alpha.24" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.1.4054" />


### PR DESCRIPTION
…quirement

According to the security compliance requirement, all open-source components used must have a release date no older than 18 months (for still-maintained components) and no older than 48 months (for components with no later version). All upgrades must target the latest stable (non-beta) version of the component.

AB#1546966