### PR TITLE
[ci] Disabling CodeQL pipeline triggers that are not scheduled

### DIFF
--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -15,6 +15,9 @@ schedules:
     include:
     - main
 
+pr: none
+trigger: none
+
 variables:
 - template: build/variables.yml
   parameters:


### PR DESCRIPTION
It's annoying that the CodeQL pipeline is running for every PR and commit. It should only run on a schedule