### PR TITLE
Fix build problems related to xunit and signing assemblies

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<config>
+		<!--
+			This configuration changes the location of the NuGet cache directory.
+			This is needed to sign NuGet binaries within the cache. Otherwise, other
+			builds may end up getting signed binaries when they do not intend to.
+		-->
+		<add key="globalPackagesFolder" value="packages" />
+	</config>
+</configuration>

--- a/build/stages/sbom.yml
+++ b/build/stages/sbom.yml
@@ -7,5 +7,5 @@ stages:
     parameters:
       packageName: 'Mobile Essentials'
       artifactNames: ['package']
-      packageFilter: '*.vsix;*.nupkg'
+      packageFilter: '*.vsix'
       packageVersionRegex: '(?i)^Merq\.(?<version>\d+\.\d+\.\d+).vsix$'

--- a/src/Vsix/Merq.Vsix.IntegrationTests/Merq.Vsix.IntegrationTests.csproj
+++ b/src/Vsix/Merq.Vsix.IntegrationTests/Merq.Vsix.IntegrationTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="ThisAssembly.Project" Version="1.0.9" PrivateAssets="all" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="xunit.runner.msbuild" Version="2.4.1" />
     <PackageReference Include="xunit.vsix" Version="0.9.3" />

--- a/src/Vsix/Merq.Vsix.IntegrationTests/Merq.Vsix.IntegrationTests.csproj
+++ b/src/Vsix/Merq.Vsix.IntegrationTests/Merq.Vsix.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="xunit.runner.msbuild" Version="2.4.1" />
-    <PackageReference Include="xunit.vsix" Version="0.5.0-beta" />
+    <PackageReference Include="xunit.vsix" Version="0.9.3" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.2.*" />
     <PackageReference Include="System.Reactive" Version="3.0.0" />
     <PackageReference Include="Merq" Version="1.3.0" />

--- a/src/Vsix/Merq.Vsix/Merq.Vsix.csproj
+++ b/src/Vsix/Merq.Vsix/Merq.Vsix.csproj
@@ -60,9 +60,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Merq" Version="1.3.0" PrivateAssets="all" IncludeInVSIX="true" />
-    <PackageReference Include="Merq.Core" Version="1.3.0" PrivateAssets="all" IncludeInVSIX="true" />
-    <PackageReference Include="Merq.VisualStudio" Version="1.3.0" PrivateAssets="all" IncludeInVSIX="true" />
+    <PackageReference Include="Merq" Version="1.3.0" PrivateAssets="all" IncludeInVSIX="true" GeneratePathProperty="true" />
+    <PackageReference Include="Merq.Core" Version="1.3.0" PrivateAssets="all" IncludeInVSIX="true" GeneratePathProperty="true" />
+    <PackageReference Include="Merq.VisualStudio" Version="1.3.0" PrivateAssets="all" IncludeInVSIX="true" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.Project" Version="1.0.9" PrivateAssets="all" />
     <PackageReference Include="Clarius.VisualStudio" Version="2.0.14" />
@@ -75,6 +75,18 @@
     <BindingRedirect Include="Merq" />
     <BindingRedirect Include="Merq.Core" />
     <BindingRedirect Include="Merq.VisualStudio" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Configuration)' == 'Release'">
+    <NuGetFilesToSign Include="$(PkgMerq)\lib\netstandard2.0\Merq.dll">
+      <Authenticode>3PartySHA2</Authenticode>
+    </NuGetFilesToSign>
+    <NuGetFilesToSign Include="$(PkgMerq_Core)\lib\netstandard2.0\Merq.Core.dll" >
+      <Authenticode>3PartySHA2</Authenticode>
+    </NuGetFilesToSign>
+    <NuGetFilesToSign Include="$(PkgMerq_VisualStudio)\lib\net472\Merq.VisualStudio.dll" >
+      <Authenticode>3PartySHA2</Authenticode>
+    </NuGetFilesToSign>
   </ItemGroup>
 
   <!--
@@ -98,9 +110,6 @@
     <ItemGroup>
       <FilesToSign Include="$(IntermediateOutputPath)Merq.Vsix.dll">
         <Authenticode>Microsoft400</Authenticode>
-      </FilesToSign>
-      <FilesToSign Include="@(MerqFile->'$(OutDir)%(Filename)%(Extension)')">
-        <Authenticode>3PartySHA2</Authenticode>
       </FilesToSign>
     </ItemGroup>
   </Target>

--- a/src/Vsix/Merq.Vsix/Merq.Vsix.csproj
+++ b/src/Vsix/Merq.Vsix/Merq.Vsix.csproj
@@ -97,7 +97,7 @@
   <Target Name="GetFilesToSign" BeforeTargets="SignVsixContentFiles" DependsOnTargets="IncludeNuGetResolvedAssets" Condition="'$(Configuration)' == 'Release'">
     <ItemGroup>
       <FilesToSign Include="$(IntermediateOutputPath)Merq.Vsix.dll">
-        <Authenticode>3PartySHA2</Authenticode>
+        <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>
       <FilesToSign Include="@(MerqFile->'$(OutDir)%(Filename)%(Extension)')">
         <Authenticode>3PartySHA2</Authenticode>
@@ -113,9 +113,8 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="CopySignedNuGetFilesToPackageDir" AfterTargets="SignFiles" Condition="'$(Configuration)' == 'Release'">
+  <Target Name="CopySignedVsixToPackageDir" AfterTargets="SignFiles" Condition="'$(Configuration)' == 'Release'">
     <ItemGroup>
-      <SignedFiles Include="$(OutDir)Merq*.dll" />
       <SignedFiles Include="$(OutDir)$(TargetVsixContainerName)" />
     </ItemGroup>
     <Copy SourceFiles="@(SignedFiles)" DestinationFolder="$(PackageOutputPath)" />


### PR DESCRIPTION
- xunit packages needed to be updated to their latest stable versions
- Stopped publishing as artifacts Merq assemblies, and keep only the vsix file
- Sign the Merq.Vsix assembly with `Microsoft400` since it is an assembly produced by Microsoft