### PR TITLE
Bumping Merq to 1.5.0

### DIFF
--- a/src/Vsix/Merq.Vsix.IntegrationTests/Merq.Vsix.IntegrationTests.csproj
+++ b/src/Vsix/Merq.Vsix.IntegrationTests/Merq.Vsix.IntegrationTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="xunit.vsix" Version="0.9.3" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.2.*" />
     <PackageReference Include="System.Reactive" Version="3.0.0" />
-    <PackageReference Include="Merq" Version="1.3.0" />
+    <PackageReference Include="Merq" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Vsix/Merq.Vsix/Merq.Vsix.csproj
+++ b/src/Vsix/Merq.Vsix/Merq.Vsix.csproj
@@ -60,9 +60,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Merq" Version="1.3.0" PrivateAssets="all" IncludeInVSIX="true" GeneratePathProperty="true" />
-    <PackageReference Include="Merq.Core" Version="1.3.0" PrivateAssets="all" IncludeInVSIX="true" GeneratePathProperty="true" />
-    <PackageReference Include="Merq.VisualStudio" Version="1.3.0" PrivateAssets="all" IncludeInVSIX="true" GeneratePathProperty="true" />
+    <PackageReference Include="Merq" Version="1.5.0" PrivateAssets="all" IncludeInVSIX="true" GeneratePathProperty="true" />
+    <PackageReference Include="Merq.Core" Version="1.5.0" PrivateAssets="all" IncludeInVSIX="true" GeneratePathProperty="true" />
+    <PackageReference Include="Merq.VisualStudio" Version="1.5.0" PrivateAssets="all" IncludeInVSIX="true" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.Project" Version="1.0.9" PrivateAssets="all" />
     <PackageReference Include="Clarius.VisualStudio" Version="2.0.14" />


### PR DESCRIPTION
## Description
Bumping Merq packages to latest public version, 1.5.0
AB#1767539: Merq assemblies inserted into VS are reverted to 1.3.0 assembly version

## PR Checklist
- [X] Title is meaningful
- [X] Work Item is linked
- [X] Changes are described

- **Tests**
  - [ ] Automated tests are added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [X] N/A -- updating package version.
  - **OR**
  - [ ] Upcoming sprint Work Item: <!-- link -->
  - **OR**
  - [ ] Test exception <!-- include short explanation -->
