### PR TITLE
[ci] Dependabot Improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,10 @@ updates:
       # https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1776264
       - dependency-name: "Microsoft.Build.Artifacts"
         versions: [">=4.2.0"]
+    groups:
+       nugets:
+          patterns:
+            - "*"
 
   - package-ecosystem: gitsubmodule
     directory: "/"
@@ -38,3 +42,7 @@ updates:
     open-pull-requests-limit: 10
     assignees:
     - xamarin/vscx-tools-platform
+    groups:
+       submodules:
+          patterns:
+            - "*"

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,0 +1,19 @@
+name: Dependabot Approve
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabotApprove:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request && github.event.issue.user.login == 'dependabot[bot]' && startswith(github.event.comment.body, '@gitbot dependabot-approve') }}
+    steps:
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.issue.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.SERVICEACCOUNT_PAT }}


### PR DESCRIPTION
Make dependabot only send 1 commit and allow auto approval by commenting `@gitbot dependabot-approve` on dependabot PRs