### PR TITLE
Allow GH actions to continue working

### DIFF
--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -7,6 +7,13 @@ on:
 jobs:
   setupBackport:
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requires permissions block
+    # https://docs.opensource.microsoft.com/github/apps/permission-changes/
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      actions: write
+      contents: read
+      security-events: write
     if: github.event.issue.pull_request != '' && startswith(github.event.comment.body, '@gitbot backport')
     outputs:
       target_branch: ${{ steps.parse_comment.outputs.target_branch }}

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -10,6 +10,13 @@ permissions:
 jobs:
   dependabotApprove:
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requires permissions block
+    # https://docs.opensource.microsoft.com/github/apps/permission-changes/
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      actions: write
+      contents: read
+      security-events: write
     if: ${{ github.event.issue.pull_request && github.event.issue.user.login == 'dependabot[bot]' && startswith(github.event.comment.body, '@gitbot dependabot-approve') }}
     steps:
       - name: Approve a PR

--- a/.github/workflows/rebase-trigger.yml
+++ b/.github/workflows/rebase-trigger.yml
@@ -7,6 +7,13 @@ on:
 jobs:
   launchBackportBuild:
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requires permissions block
+    # https://docs.opensource.microsoft.com/github/apps/permission-changes/
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      actions: write
+      contents: read
+      security-events: write
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '@gitbot rebase')
 
     steps:


### PR DESCRIPTION
Allow GH actions to continue working

GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requires permissions block
https://docs.opensource.microsoft.com/github/apps/permission-changes/
https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

Part of: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1946731