### PR TITLE
Update SDL Analysis pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ extends:
         configFile: $(System.DefaultWorkingDirectory)\build\tsaoptions-v2.json
     pool:
       name: AzurePipelines-EO
-      image: AzurePipelinesWindows2022compliantGPT
+      image: 1ESPT-Windows2022
       os: windows
     stages:
     - template: /build/stages/build.yml@self


### PR DESCRIPTION
## Description
The original image VSEng provided has some issues with the auto-baselining task. It will eventually be deprecated, so we're switching to the new image: 1ESPT-Windows2022
