### PR TITLE
Adding explicit package references to fix CG alerts

### DIFF
--- a/src/Merq.props
+++ b/src/Merq.props
@@ -32,6 +32,11 @@
 
 		<Version>0.0.0</Version>
 	</PropertyGroup>
+
+	<PropertyGroup>
+		<MicrosoftIORedistVersion>6.0.1</MicrosoftIORedistVersion>
+		<SystemTextJsonVersion>8.0.4</SystemTextJsonVersion>
+	</PropertyGroup>
 	
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		<Optimize>false</Optimize>

--- a/src/Vsix/Merq.Vsix.IntegrationTests/Merq.Vsix.IntegrationTests.csproj
+++ b/src/Vsix/Merq.Vsix.IntegrationTests/Merq.Vsix.IntegrationTests.csproj
@@ -12,8 +12,10 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageReference Include="xunit.runner.msbuild" Version="2.7.0" />
     <PackageReference Include="xunit.vsix" Version="0.9.3" />
+    <PackageReference Include="Microsoft.IO.Redist" Version="$(MicrosoftIORedistVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.10.39856" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <PackageReference Include="Merq" Version="1.5.0" />
   </ItemGroup>
 

--- a/src/Vsix/Merq.Vsix/Merq.Vsix.csproj
+++ b/src/Vsix/Merq.Vsix/Merq.Vsix.csproj
@@ -64,12 +64,14 @@
     <PackageReference Include="Merq" Version="1.5.0" PrivateAssets="all" IncludeInVSIX="true" GeneratePathProperty="true" />
     <PackageReference Include="Merq.Core" Version="1.5.0" PrivateAssets="all" IncludeInVSIX="true" GeneratePathProperty="true" />
     <PackageReference Include="Merq.VisualStudio" Version="1.5.0" PrivateAssets="all" IncludeInVSIX="true" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.IO.Redist" Version="$(MicrosoftIORedistVersion)" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.Project" Version="1.1.3" PrivateAssets="all" />
     <PackageReference Include="Clarius.VisualStudio" Version="2.0.14" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.7.2189" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.7.37327" />
     <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.36" ExcludeAssets="all" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Fixing two CG alerts that come from transitive package references:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2135048
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2135049

Note: I don't know why it's showing Merq.Vsix.csproj as being edited when I'm only adding two lines to itach. If anyone knows how to fix this, please let me know.

## PR Checklist
- [x] Title is meaningful
- [x] Work Item is linked
- [x] Changes are described

- **Tests**
  - [ ] Automated tests are added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] N/A: Infrastructure
  - **OR**
  - [ ] Upcoming sprint Work Item: <!-- link -->
  - **OR**
  - [ ] Test exception <!-- include short explanation -->
