### PR TITLE
Updating pipeline to run twice a month, even if there's no changes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,14 @@ pr:
   - d16-*
   - d17-*
 
+schedules:
+- cron: "0 0 1,15 * *" # Runs at midnight (UTC) on the 1st and 15th of every month
+  displayName: "Twice a Month Schedule"
+  branches:
+    include:
+      - main
+  always: true    # Ensures it runs even if there are no code changes
+
 variables:
 - template: /build/variables.yml@self
 


### PR DESCRIPTION
## Description
Pipeline will run on the first and fifteenth of every month, even if there haven't been any changes. This is mainly done so that there's always recent compliance data.

Task https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2268475

## PR Checklist
- [x] Title is meaningful
- [x] Work Item is linked
- [x] Changes are described

- **Tests**
  - [ ] Automated tests are added
  - **OR**
  <!-- Describe why you haven't added automation. -->
  - [x] N/A: Infrastructure
  - **OR**
  - [ ] Upcoming sprint Work Item: <!-- link -->
  - **OR**
  - [ ] Test exception <!-- include short explanation -->
